### PR TITLE
Use with zipfile.ZipFile('Phantom.zip') as zipped

### DIFF
--- a/Phantom_installer.py
+++ b/Phantom_installer.py
@@ -12,9 +12,8 @@ print "Downloading..."
 url = 'https://github.com/671620616/PhantomChess/archive/master.zip'
 urllib.urlretrieve(url, 'Phantom.zip')
 print "Unzipping..."
-zipped = zipfile.ZipFile('Phantom.zip', 'r')
-zipped.extractall()
-zipped.close()
+with zipfile.ZipFile('Phantom.zip', 'r') as zipped:
+    zipped.extractall()
 print "Adding to importable location..."
 for p in sys.path:
     if os.path.split(p)[1] == 'site-packages':


### PR DESCRIPTION
This syntax ensures the file is closed even if an exception is thrown.