### PR TITLE
Deal with read-only site-packages on homebrew-installed Python on Mac OS...

### DIFF
--- a/Phantom_installer.py
+++ b/Phantom_installer.py
@@ -1,35 +1,47 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Run this file to download PhantomChess to the directory of this file.
+Run this file to download PhantomChess to the current working directory and install it in site-packages.
 """
-print "Preparing to install..."
-import zipfile
+print('=' * 31)
+
 import os
 import shutil
-import urllib
 import sys
-print "Downloading..."
+import urllib
+import zipfile
+
+module_name = 'Phantom'
+print('Preparing to install {}...'.format(module_name))
+master_name = module_name + 'Chess-master'
+zip_filename = module_name + '.zip'
 url = 'https://github.com/671620616/PhantomChess/archive/master.zip'
-urllib.urlretrieve(url, 'Phantom.zip')
-print "Unzipping..."
-with zipfile.ZipFile('Phantom.zip', 'r') as zipped:
+
+print('Downloading {}...'.format(zip_filename))
+urllib.urlretrieve(url, zip_filename)
+print('Unzipping {}...'.format(zip_filename))
+with zipfile.ZipFile(zip_filename, 'r') as zipped:
     zipped.extractall()
-print "Adding to importable location..."
+print('Adding {} to importable location...'.format(module_name))
 for p in sys.path:
     if os.path.split(p)[1] == 'site-packages':
-        copyto = os.path.join(p, 'Phantom')
+        copyto = os.path.join(p, module_name)
         try:
             shutil.rmtree(copyto)
         except:
             pass
-        shutil.copytree(os.path.join('PhantomChess-master', 'Phantom'), copyto)
-print "Cleaing up..."
+        try:
+            shutil.copytree(os.path.join(master_name, module_name), copyto)
+            print('Successfully copied {} to: {}'.format(module_name, copyto))
+# a homebrew installed Python on Mac OS X has a read-only /Library/Python/2.7/site-packages
+        except OSError as e:
+            print('Failed to copy {} to: {} ({})'.format(module_name, copyto, e))
+print('Cleanng up...')
 try:
-    shutil.rmtree('Phantom')
+    shutil.rmtree(module_name)
 except:
     pass
-shutil.copytree(os.path.join('PhantomChess-master', 'Phantom'), 'Phantom')
-shutil.rmtree('PhantomChess-master')
-os.remove('Phantom.zip')
-print "Done!"
+shutil.copytree(os.path.join(master_name, module_name), module_name)
+shutil.rmtree(master_name)
+os.remove(zip_filename)
+print('Done! {}'.format('=' * 25))


### PR DESCRIPTION
A [homebrew](http://brew.sh) installed Python on Mac OS X has a read-only `/Library/Python/2.7/site-packages` and a read-write `/usr/local/lib/python2.7/site-packages`.  This version warns the user of the failure to install on the former but continues to successfully install Phantom in the latter.

Added `module_name`,  `master_name`, `zip_filename` to increase portability to other modules.

Switched to `print()` as a function.